### PR TITLE
Fixed link to screenshot for Umbraco marketplace

### DIFF
--- a/umbraco-marketplace.json
+++ b/umbraco-marketplace.json
@@ -22,7 +22,7 @@
     "PackageType": "Package",
     "Screenshots": [
       {
-        "ImageUrl": "https://github.com/Matthew-Wise/feature-flagging-umbraco/images/data-type-settings.png",
+        "ImageUrl": "https://raw.githubusercontent.com/Matthew-Wise/feature-flagging-umbraco/main/images/data-type-settings.png",
         "Caption": "Data Type prevalue settings"
       }
     ],


### PR DESCRIPTION
Just spotted this one when looking at error logs - think we can't request directly from a GitHub link as this gives a 404, it needs to be the "raw" content link instead.